### PR TITLE
💄fixed hyperlink color and added target blank to accessory pages

### DIFF
--- a/app/views/static/conduct.html.erb
+++ b/app/views/static/conduct.html.erb
@@ -63,18 +63,18 @@
     Individuals can reach us in person, via Slack (including private messaging), and via the contact information listed below:
   </p>
   <p class="my-3">
-    Chelsea Kaufman: <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="mailto:Chelsea@learnacademy.org">Chelsea@learnacademy.org</a>
+    Chelsea Kaufman: <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:Chelsea@learnacademy.org">Chelsea@learnacademy.org</a>
   </p>
   <p class="my-3">
-    Bryan Banville: <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="mailto:Bryan@learnacademy.org">Bryan@learnacademy.org</a>
+    Sarah Proctor: <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:Sarah@learnacademy.org">Sarah@learnacademy.org</a>
   </p>
   <p class="my-3">
-    Sources: <a class="text-learngreen hover:text-learngreen active:text-learngreen" target="_blank" href="https://www.djangoproject.com/conduct/">Django Code of Conduct</a>, <a class="text-learngreen hover:text-learngreen active:text-learngreen" target="_blank" href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Responding_to_reports">Geek Feminism Wiki – Responding to Reports</a>, <a class="text-learngreen hover:text-learngreen active:text-learngreen" target="_blank" href="https://github.com/sumeetjain/code_of_conduct">Omaha Code School – Code Of Conduct</a>
+    Sources: <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://www.djangoproject.com/conduct/">Django Code of Conduct</a>, <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Responding_to_reports">Geek Feminism Wiki – Responding to Reports</a>, <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://github.com/sumeetjain/code_of_conduct">Omaha Code School – Code Of Conduct</a>
   </p>
   <p class="my-3">
-     Learn more about brave spaces here: Arao, Brian and Kristi Clemens. “Safe Spaces to Brave Spaces: A New Way to Frame Dialogue Around Diversity and Social Justice.” The Art of Effective Facilitation, edited by <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="https://www.google.com/search?q=Lisa+M.+Landreman">Lisa M. Landreman</a>, Stylus Publishing, 2013, pp. 135-150. <a class="text-learngreen hover:text-learngreen active:text-learngreen" target="_blank" href="https://www.gvsu.edu/cms4/asset/843249C9-B1E5-BD47-A25EDBC68363B726/from-safe-spaces-to-brave-spaces.pdf">https://www.gvsu.edu/cms4/asset/843249C9-B1E5-BD47-A25EDBC68363B726/from-safe-spaces-to-brave-spaces.pdf</a>
+     Learn more about brave spaces here: Arao, Brian and Kristi Clemens. “Safe Spaces to Brave Spaces: A New Way to Frame Dialogue Around Diversity and Social Justice.” The Art of Effective Facilitation, edited by <strong>Lisa M. Landreman</strong>, Stylus Publishing, 2013, pp. 135-150. <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://www.gvsu.edu/cms4/asset/843249C9-B1E5-BD47-A25EDBC68363B726/from-safe-spaces-to-brave-spaces.pdf">Click here to read more about it</a>.
   </p>
   <p class="my-3">
-    More about netizenship (<a class="text-learngreen hover:text-learngreen active:text-learngreen" target="_blank" href="https://en.wikipedia.org/wiki/Netizen">https://en.wikipedia.org/wiki/Netizen</a>)
+    More about netizenship (<a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://en.wikipedia.org/wiki/Netizen">https://en.wikipedia.org/wiki/Netizen</a>)
   </p>
 </div>

--- a/app/views/static/privacy.html.erb
+++ b/app/views/static/privacy.html.erb
@@ -10,10 +10,10 @@
   </p>
   <address>2986 Ivy Street, San Diego, CA 92104</address>
   <p class="my-3">
-    <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="tel:619-789-6537">(619)-789-6537</a>
+    <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="tel:619-789-6537">(619)-789-6537</a>
   </p>
   <p class="my-3">
-    It is LEARN academy’s policy to respect your privacy regarding any information we may collect while operating our website. This Privacy Policy applies to <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="https://www.learnacademy.org">https://www.learnacademy.org</a> " (hereinafter, “us”, “we”, or “https://www.learnacademy.org”). We respect your privacy and are committed to protecting personally identifiable information you may provide us through the Website. We have adopted this privacy policy (“Privacy Policy”) to explain what information may be collected on our Website, how we use this information, and under what circumstances we may disclose the information to third parties. This Privacy Policy applies only to information we collect through the Website and does not apply to our collection of information from other sources.
+    It is LEARN academy’s policy to respect your privacy regarding any information we may collect while operating our website. This Privacy Policy applies to <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="https://www.learnacademy.org" target="_blank" >https://www.learnacademy.org</a> " (hereinafter, “us”, “we”, or “https://www.learnacademy.org”). We respect your privacy and are committed to protecting personally identifiable information you may provide us through the Website. We have adopted this privacy policy (“Privacy Policy”) to explain what information may be collected on our Website, how we use this information, and under what circumstances we may disclose the information to third parties. This Privacy Policy applies only to information we collect through the Website and does not apply to our collection of information from other sources.
   </p>
   <p class="my-3">
     This Privacy Policy, together with the Terms and conditions posted on our Website, set forth the general rules and policies governing your use of our Website. Depending on your activities when visiting our Website, you may be required to agree to additional terms and conditions.
@@ -80,6 +80,6 @@
     Credit & Contact Information
   </h2>
   <p class="my-3">
-    This privacy policy was created at termsandconditionstemplate.com. If you have any questions about this Privacy Policy, please contact us via <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="mailto:">email</a>  or  <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="tel:6197896537">phone</a>.
+    This privacy policy was created at termsandconditionstemplate.com. If you have any questions about this Privacy Policy, please contact us via <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:">email</a>  or  <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="tel:6197896537">phone</a>.
   </p>
 </div>

--- a/app/views/static/terms.html.erb
+++ b/app/views/static/terms.html.erb
@@ -13,7 +13,7 @@
   </p>
   <address>2986 Ivy Street, San Diego, CA 92104</address>
   <p class="my-3">
-    <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="tel:619-789-6537">(619)-789-6537</a>
+    <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="tel:619-789-6537">(619)-789-6537</a>
   </p>
   <p class="my-3">
     By accessing this website we assume you accept these terms and conditions in full. Do not continue to use LEARN academy’s website if you do not accept all of the terms and conditions stated on this page.
@@ -32,7 +32,7 @@
   </p>
   <h2 class="text-learnblack text-2xl">License</h2>
   <p class="my-3">
-    Unless otherwise stated, LEARN academy and/or it’s licensors own the intellectual property rights for all material on LEARN academy. All intellectual property rights are reserved. You may view and/or print pages from <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="https://www.learnacademy.org" target="_blank">LEARN academy's website</a> for your own personal use subject to restrictions set in these terms and conditions.
+    Unless otherwise stated, LEARN academy and/or it’s licensors own the intellectual property rights for all material on LEARN academy. All intellectual property rights are reserved. You may view and/or print pages from <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="https://www.learnacademy.org" target="_blank">LEARN academy's website</a> for your own personal use subject to restrictions set in these terms and conditions.
   </p>
   <p class="my-3">
     You must not:
@@ -116,7 +116,7 @@
     These organizations may link to our home page, to publications or to other Web site information so long as the link: (a) is not in any way misleading; (b) does not falsely imply sponsorship, endorsement or approval of the linking party and it products or services; and (c) fits within the context of the linking party’s site.
   </p>
   <p class="my-3">
-    If you are among the organizations listed in paragraph 2 above and are interested in linking to our website, you must notify us by sending an e-mail to <a class="text-learngreen hover:text-learngreen active:text-learngreen" href="mailto:hello@learnacademy.org">hello@learnacademy.org</a> Please include your name, your organization name, contact information (such as a phone number and/or e-mail address) as well as the URL of your site, a list of any URLs from which you intend to link to our Web site, and a list of the URL(s) on our site to which you would like to link. Allow 2-3 weeks for a response.
+    If you are among the organizations listed in paragraph 2 above and are interested in linking to our website, you must notify us by sending an e-mail to <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:hello@learnacademy.org">hello@learnacademy.org</a> Please include your name, your organization name, contact information (such as a phone number and/or e-mail address) as well as the URL of your site, a list of any URLs from which you intend to link to our Web site, and a list of the URL(s) on our site to which you would like to link. Allow 2-3 weeks for a response.
   </p>
   <p class="my-3">
     Approved organizations may hyperlink to our Web site as follows:


### PR DESCRIPTION
# Submitting Pull Request

### Ticket

ID number: 80

Branch name: Accessory Pages

Description: Changed the links to learn-purple and target blanks were added to website links, made url stub for conduct page link, swapped Bryan's info for Sarah's

Link to ticket: https://www.notion.so/3c617b3aba60438ea07f6065f97dafb4?v=ed93b67784f4486eaad077353b10faca&p=4953f08b6eaa41b0abe3248573d7b156&pm=s

### Notes

Notes for the reviewer:

Contributors: Will, Nicole, Luis
