### PR TITLE
💄Admin Dashboard updated

### DIFF
--- a/app/assets/stylesheets/administrate/base/_tables.scss
+++ b/app/assets/stylesheets/administrate/base/_tables.scss
@@ -5,6 +5,9 @@ table {
   width: 100%;
 
   a {
+    &:hover{
+      color: $learnpurple;
+    }
     color: inherit;
     text-decoration: none;
   }

--- a/app/assets/stylesheets/administrate/library/_variables.scss
+++ b/app/assets/stylesheets/administrate/library/_variables.scss
@@ -19,7 +19,7 @@ $small-spacing: $base-spacing / 2 !default;
 // Colors
 $white: #fff !default;
 $black: #000 !default;
-
+$learnpurple: #A670AF !default;
 $blue: #1976d2 !default;
 $red: #d32f2f !default;
 $light-yellow: #f0cd66 !default;
@@ -35,7 +35,7 @@ $hint-grey: #7b808c !default;
 
 // Font Colors
 $base-font-color: $grey-7 !default;
-$action-color: $blue !default;
+$action-color: $learnpurple !default;
 
 // Background Colors
 $base-background-color: $grey-0 !default;

--- a/app/views/admin/application/_collection.html.erb
+++ b/app/views/admin/application/_collection.html.erb
@@ -1,0 +1,83 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+        cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+          collection_presenter.order_params_for(attr_name, key: collection_field_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: resource_class.human_attribute_name(attr_name),
+        ).titleize %>
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <%= render(
+        "collection_header_actions",
+        collection_presenter: collection_presenter,
+        page: page,
+        resources: resources,
+        table_title: "page-title"
+      ) %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          <% if valid_action?(:show, resource.class) && show_action?(:show, resource) %>
+            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if valid_action?(:show, resource.class) && show_action?(:show, resource) -%>
+              <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 tabindex="-1"
+                 class="action-show"
+                 >
+                <%= render_field attribute %>
+              </a>
+            <% else %>
+              <%= render_field attribute %>
+            <% end -%>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -1,0 +1,57 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= page.page_title %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+
+    <%= link_to(
+      t("administrate.actions.destroy"),
+      [namespace, page.resource],
+      class: "button button--danger",
+      method: :delete,
+      data: { confirm: t("administrate.actions.confirm") }
+    ) if valid_action?(:destroy) && show_action?(:destroy, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: page.resource.class.human_attribute_name(attribute.name),
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute, page: page %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -11,7 +11,9 @@ By default, it renders:
 - Flashes
 - Links to stylesheets and JavaScripts
 %>
-
+<div class="flex flex-wrap items-center justify-between px-8 py-2 h-32 w-full bg-learngray text-sm font-medium">
+  <%= render_svg "logo", styles: "fill-current text-gray-700 hover:text-gray-800" %>
+</div>
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -73,7 +73,7 @@
 
                 <% if current_user.admin? %>
                   <div class="px-6 py-3 text-xs font-bold text-gray-800 uppercase bg-white border-t border-gray-200"><%= t(".admin") %></div>
-                  <%= link_to t(".dashboard"), admin_root_path, class: 'no-underline block px-6 py-3 text-gray-800 bg-white  hover:bg-primary-50 transition ease-in-out duration-200 whitespace-nowrap', target: :_blank, data: { turbo: false } %>
+                  <%= link_to t(".dashboard"), admin_root_path, class: 'no-underline block px-6 py-3 text-gray-800 bg-white  hover:bg-primary-50 transition ease-in-out duration-200 whitespace-nowrap', data: { turbo: false } %>
                   <%= link_to 'Sidekiq', admin_sidekiq_web_path, class: 'no-underline block px-6 py-3 text-gray-800 bg-white  hover:bg-primary-50 transition ease-in-out duration-200 whitespace-nowrap', target: :_blank, data: { turbo: false } if defined?(::Sidekiq) %>
                 <% end %>
                 <% if Rails.env.development? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -480,6 +480,11 @@ en:
 
   helpers:
     label:
+      cohort:
+        cohort_name: "Cohort"
+        cohort_year: "Year"
+      student:
+        student_name: "Name"
       country: "Country or region"
       account:
         name: "Account Name"


### PR DESCRIPTION
# Submitting Pull Request

### Ticket

ID number: 81

Branch name: admin-dash

Description: 
- [x]  Header on admin pages
    - Might be under dashboard shared
    - Might be editing a dashboard show page
- [x]  Prevent new tab from opening when navigating to admin dashboard
- Cohort Index
    - [x]  Remove edit and delete on index page (already buttons on show page)
    - [x]  Cohort name → name
    - [x]  Cohort year → year
    - [x]  Hover should be purple on headings
- Cohort Show
    - [x]  Remove “show” from header so it just says cohort
    - [x]  Hover should be purple on headings and all clickables
    - [x]  Remove edit and delete on student row (already on show page)

Link to ticket: https://www.notion.so/2022-Delta-Internship-6af24e8d3bb349ea8fe44f3d6351f036?p=2a017669ce9e48aa9113e3631b799aee&pm=s

### Notes

Notes for the reviewer:

Contributors: Don, Will, Nicole, Gene
