### PR TITLE
fixed sidebar on mobile and about us character count

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
-<nav class="flex flex-wrap items-center justify-between px-8 py-2 h-32 w-full bg-learngray text-sm font-medium" data-controller="toggle">
+<nav class="flex flex-wrap items-center justify-between px-8 py-2 h-auto w-full bg-learngray text-sm font-medium" data-controller="toggle">
   <div class="flex items-center flex-shrink-0 mr-6">
     <%= link_to root_path do %>
-      <%= render_svg "logo", styles: "fill-current text-gray-700 hover:text-gray-800" %>
+      <%= render_svg "logo", styles: "fill-current text-gray-700 hover:text-gray-800 h-32" %>
       <span class="sr-only"><%= ENV.fetch('APP_NAME', '') %></span>
     <% end %>
   </div>

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-learnpurple mt-4 mb-12">
     <%= t(".title") %>
   </h1>
-  <p class="my-3 w-[60%]">
+  <p class="my-3 w-[80%]">
     With equal access to knowledge and career development, LEARN academy is teaching a new generation of daring and diverse students to be compassionate, curious and professional web developers. (Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.)
   </p>
 </div>


### PR DESCRIPTION
# Submitting Pull Request

### Ticket

ID number: "empty"

Branch name: mobile-audit

Description: Fixed the mobile dropdown when open and fixed the length of the About Us page

Link to ticket: https://www.notion.so/2022-Foxtrot-Internship-37b61f8be4c648e882305901c0f16b55?p=f287a57f800e4219963683025e36871c&pm=s

### Notes

Notes for the reviewer: no ID number on notion card

Contributors: Nate, Christian, Kyle, and Francisco
