### PR TITLE
:iphone: Fixed text

### DIFF
--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -2,7 +2,7 @@
   <h1 class="text-learnpurple mt-4 mb-12">
     <%= t(".title") %>
   </h1>
-  <p class="my-3 w-[60%]">
+  <p class="my-3" style="max-width:54ch">
     With equal access to knowledge and career development, LEARN academy is teaching a new generation of daring and diverse students to be compassionate, curious and professional web developers. (Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.)
   </p>
 </div>

--- a/app/views/static/conduct.html.erb
+++ b/app/views/static/conduct.html.erb
@@ -2,79 +2,79 @@
   <h1 class="text-learnpurple mt-4 mb-12">
     <%= t(".title") %>
   </h1>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     At LEARN academy, we strive to be a positive voice in the San Diego Tech Community. Our goals are to be welcoming and inclusive and to provide a space for any person who wants to code. 
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     The administration at LEARN academy, endeavors to build a brave, inclusive space—online, in the classroom, and at our events. A primary assumption of a brave space is that everyone speaks with the positive intent of seeking greater knowledge and understanding of differing perspectives and experiences. To promote a spirit of inclusivity, we ask our instructors, students, mentors, and guests to follow a few foundational principles while sharing our space. These principles are embodied by, but not limited to, the following statements:
   </p>
   <h2 class="text-learnblack text-2xl">
     We are Welcoming, Friendly, and Patient
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We make sure that our actions do not obstruct others from their learning.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     It is crucial that every individual knows that LEARN academy is an inclusive, respectful, community-oriented learning environment. Each individual in the LEARN academy community has a part to play in building and maintaining these principles.
   </p>
   <h2 class="text-learnblack text-2xl">
     We are Considerate
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Individuals’ work and decisions affect others. Whether writing code, giving a presentation or participating in a discussion, individuals’ actions have consequences. Individuals should take those consequences into account when making decisions.
   </p>
   <h2 class="text-learnblack text-2xl">
     We are Respectful
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We can all experience frustration now and then; coding is hard work and can be exasperating. How can we ensure that frustration does not get in the way of positive, productive relationships with others? Give yourself grace if you feel frustrated with coding, another member of our community, or with yourself. LEARN staff is available at any time for individuals who need to talk through frustration or need help facilitating communication with another member of the community.
   </p>
   <h2 class="text-learnblack text-2xl">
     We are Mindful of Vocabulary
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Remember that sexist, racist, and other exclusionary jokes or media content can be offensive to others. Consider the content of the music you play, the videos you stream, the images you share, and the language you use in our learning space. Do they contain words or images that some may find offensive or denigrating? Be kind to others, and do not insult or put down another person. Mindfulness often means reevaluating what we consider permissible.
   </p>
   <h2 class="text-learnblack text-2xl">
     We use our Skills for Good
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Computers are a revolutionary communication tool, which connects us like never before. With this connectivity comes a responsibility to respect others’ property and rights on the internet. Our duty goes beyond following the law, which is a must. At LEARN academy, we use our facility, resources, and skills to do “good” in the community. We help others make the internet safe as well, by following best practices of netizenship, such as reporting issues found on the internet or within our community in a manner consistent with LEARN academy’s values.
   </p>
   <h2 class="text-learnblack text-2xl">
     Reporting Inappropriate Behavior
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We care about individuals’ experiences while they are with us at LEARN academy. Chelsea and Bryan are trained in conflict resolution and diversity and inclusion issues, and they are available to talk with individuals about any topic. If an individual’s experience as a member of the LEARN academy community has made them uncomfortable, feel unwelcome, or has in any other way not met their expectations of a professional learning environment, we are here to listen and to protect the brave space.
   </p>
   <h2 class="text-learnblack text-2xl">
     At LEARN academy, we promise:
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     To take all harassment reports seriously.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     To respect individuals’ privacy.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     To remove the source of harassment. The process begins with a warning to the offender, followed by removing them from the area if the harassment continues.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Individuals can reach us in person, via Slack (including private messaging), and via the contact information listed below:
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Chelsea Kaufman: <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:Chelsea@learnacademy.org">Chelsea@learnacademy.org</a>
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Sarah Proctor: <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:Sarah@learnacademy.org">Sarah@learnacademy.org</a>
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Sources: <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://www.djangoproject.com/conduct/">Django Code of Conduct</a>, <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Responding_to_reports">Geek Feminism Wiki – Responding to Reports</a>, <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://github.com/sumeetjain/code_of_conduct">Omaha Code School – Code Of Conduct</a>
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
      Learn more about brave spaces here: Arao, Brian and Kristi Clemens. “Safe Spaces to Brave Spaces: A New Way to Frame Dialogue Around Diversity and Social Justice.” The Art of Effective Facilitation, edited by <strong>Lisa M. Landreman</strong>, Stylus Publishing, 2013, pp. 135-150. <a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://www.gvsu.edu/cms4/asset/843249C9-B1E5-BD47-A25EDBC68363B726/from-safe-spaces-to-brave-spaces.pdf">Click here to read more about it</a>.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     More about netizenship (<a class="text-learnpurple hover:text-learngreen active:text-learngreen" target="_blank" href="https://en.wikipedia.org/wiki/Netizen">https://en.wikipedia.org/wiki/Netizen</a>)
   </p>
 </div>

--- a/app/views/static/privacy.html.erb
+++ b/app/views/static/privacy.html.erb
@@ -5,65 +5,65 @@
   <h2 class="text-learnblack text-2xl">
     Your privacy is critically important to us.
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     LEARN academy is located at:
   </p>
   <address>2986 Ivy Street, San Diego, CA 92104</address>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="tel:619-789-6537">(619)-789-6537</a>
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     It is LEARN academy’s policy to respect your privacy regarding any information we may collect while operating our website. This Privacy Policy applies to <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="https://www.learnacademy.org" target="_blank" >https://www.learnacademy.org</a> " (hereinafter, “us”, “we”, or “https://www.learnacademy.org”). We respect your privacy and are committed to protecting personally identifiable information you may provide us through the Website. We have adopted this privacy policy (“Privacy Policy”) to explain what information may be collected on our Website, how we use this information, and under what circumstances we may disclose the information to third parties. This Privacy Policy applies only to information we collect through the Website and does not apply to our collection of information from other sources.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     This Privacy Policy, together with the Terms and conditions posted on our Website, set forth the general rules and policies governing your use of our Website. Depending on your activities when visiting our Website, you may be required to agree to additional terms and conditions.
   </p>
   <h2 class="text-learnblack text-2xl">
     Website Visitors
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Like most website operators, LEARN academy collects non-personally-identifying information of the sort that web browsers and servers typically make available, such as the browser type, language preference, referring site, and the date and time of each visitor request. LEARN academy’s purpose in collecting non-personally identifying information is to better understand how LEARN academy’s visitors use its website. From time to time, LEARN academy may release non-personally-identifying information in the aggregate, e.g., by publishing a report on trends in the usage of its website.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     LEARN academy also collects potentially personally-identifying information like Internet Protocol (IP) addresses for logged in users and for users leaving comments on https://www.learnacademy.org blog posts. LEARN academy only discloses logged in user and commenter IP addresses under the same circumstances that it uses and discloses personally-identifying information as described below.
   </p>
   <h2 class="text-learnblack text-2xl">
     Gathering of Personally-Identifying Information
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Certain visitors to LEARN academy’s websites choose to interact with LEARN academy in ways that require LEARN academy to gather personally-identifying information. The amount and type of information that LEARN academy gathers depends on the nature of the interaction. For example, we ask visitors who sign up for a blog at https://www.learnacademy.org to provide a username and email address.
   </p>
   <h2 class="text-learnblack text-2xl">
     Security
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     The security of your Personal Information is important to us, but remember that no method of transmission over the Internet, or method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your Personal Information, we cannot guarantee its absolute security. 
   </p>
   <h2 class="text-learnblack text-2xl">
     Advertisements
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Ads appearing on our website may be delivered to users by advertising partners, who may set cookies. These cookies allow the ad server to recognize your computer each time they send you an online advertisement to compile information about you or others who use your computer. This information allows ad networks to, among other things, deliver targeted advertisements that they believe will be of most interest to you. This Privacy Policy covers the use of cookies by LEARN academy and does not cover the use of cookies by any advertisers.
   </p>
   <h2 class="text-learnblack text-2xl">
     Links to External Sites
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Our Service may contain links to external sites that are not operated by us. If you click on a third party link, you will be directed to that third party’s site. We strongly advise you to review the Privacy Policy and terms and conditions of every site you visit.
   </p>
-  <p>
+  <p style="max-width:54ch">
     We have no control over, and assume no responsibility for the content, privacy policies or practices of any third party sites, products or services.
   </p>
-  <h2 class="text-learnblack text-2xl">
+  <h2 class="text-learnblack text-2xl my-3">
     Aggregated Statistics
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     LEARN academy may collect statistics about the behavior of visitors to its website. LEARN academy may display this information publicly or provide it to others. However, LEARN academy does not disclose your personally-identifying information.
   </p>
   <h2 class="text-learnblack text-2xl">
     Cookies
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     To enrich and perfect your online experience, LEARN academy uses “Cookies”, similar technologies and services provided by others to display personalized content, appropriate advertising and store your preferences on your computer.
   
     A cookie is a string of information that a website stores on a visitor’s computer, and that the visitor’s browser provides to the website each time the visitor returns. LEARN academy uses cookies to help LEARN academy identify and track visitors, their usage of https://www.learnacademy.org, and their website access preferences. LEARN academy visitors who do not wish to have cookies placed on their computers should set their browsers to refuse cookies before using LEARN academy’s websites, with the drawback that certain features of LEARN academy’s websites may not function properly without the aid of cookies.
@@ -73,13 +73,13 @@
   <h2 class="text-learnblack text-2xl">
     Privacy Policy Changes
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Although most changes are likely to be minor, LEARN academy may change its Privacy Policy from time to time, and in LEARN academy’s sole discretion. LEARN academy encourages visitors to frequently check this page for any changes to its Privacy Policy. Your continued use of this site after any change in this Privacy Policy will constitute your acceptance of such change.
   </p>
   <h2 class="text-learnblack text-2xl">
     Credit & Contact Information
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     This privacy policy was created at termsandconditionstemplate.com. If you have any questions about this Privacy Policy, please contact us via <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:">email</a>  or  <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="tel:6197896537">phone</a>.
   </p>
 </div>

--- a/app/views/static/terms.html.erb
+++ b/app/views/static/terms.html.erb
@@ -5,49 +5,49 @@
   <h2 class="text-learnblack text-2xl">
     Welcome to LEARN academy
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     These terms and conditions outline the rules and regulations for the use of LEARN academy’s Website.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     LEARN academy is located at:
   </p>
   <address>2986 Ivy Street, San Diego, CA 92104</address>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="tel:619-789-6537">(619)-789-6537</a>
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     By accessing this website we assume you accept these terms and conditions in full. Do not continue to use LEARN academy’s website if you do not accept all of the terms and conditions stated on this page.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     The following terminology applies to these Terms and Conditions, Privacy Statement and Disclaimer Notice and any or all Agreements: “Client”, “You” and “Your” refers to you, the person accessing this website and accepting the Company’s terms and conditions. “The Company”, “Ourselves”, “We”, “Our” and “Us”, refers to our Company. “Party”, “Parties”, or “Us”, refers to both the Client and ourselves, or either the Client or ourselves. All terms refer to the offer, acceptance and consideration of payment necessary to undertake the process of our assistance to the Client in the most appropriate manner, whether by formal meetings of a fixed duration, or any other means, for the express purpose of meeting the Client’s needs in respect of provision of the Company’s stated services/products, in accordance with and subject to, prevailing law of United States. Any use of the above terminology or other words in the singular, plural, capitalization and/or he/she or they, are taken as interchangeable and therefore as referring to same.
   </p>
   <h2 class="text-learnblack text-2xl">
     Cookies
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We employ the use of cookies. By using LEARN academy’s website you consent to the use of cookies in accordance with LEARN academy’s privacy policy.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Most of the modern day interactive web sites use cookies to enable us to retrieve user details for each visit. Cookies are used in some areas of our site to enable the functionality of this area and ease of use for those people visiting. Some of our affiliate/advertising partners may also use cookies.
   </p>
   <h2 class="text-learnblack text-2xl">License</h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Unless otherwise stated, LEARN academy and/or it’s licensors own the intellectual property rights for all material on LEARN academy. All intellectual property rights are reserved. You may view and/or print pages from <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="https://www.learnacademy.org" target="_blank">LEARN academy's website</a> for your own personal use subject to restrictions set in these terms and conditions.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     You must not:
   </p>
   <ol>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       Republish material from https://www.learnacademy.org
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       Sell, rent or sub-license material from https://www.learnacademy.org
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       Reproduce, duplicate or copy material from https://www.learnacademy.org
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       Redistribute content from LEARN academy (unless the content is specifically made for redistribution)
     </li>
   </ol>
@@ -55,137 +55,137 @@
     Hyperlinking to our Content
   </h2>
   <ol>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       The following organizations may link to our Web site without prior written approval:
       <ol class="ml-8">
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           Government agencies;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           Search engines;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           News organizations;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           Online directory distributors when they list us in the directory may link to our Web site in the same manner as they hyperlink to the Web sites of other listed businesses; and
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           Systemwide Accredited Businesses except soliciting non-profit organizations, charity shopping malls, and charity fundraising groups which may not hyperlink to our Web site.
         </li>
       </ol>
     </li>  
   </ol> 
   <ol start="2">
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       These organizations may link to our home page, to publications or to other Web site information so long as the link: (a) is not in any way misleading; (b) does not falsely imply sponsorship, endorsement or approval of the linking party and its products or services; and (c) fits within the context of the linking party’s site.
     </li>
   </ol>
   <ol start="3">
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       We may consider and approve in our sole discretion other link requests from the following types of organizations:
       <ol class="ml-8">
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           commonly-known consumer and/or business information sources such as Chambers of Commerce, American Automobile Association, AARP and Consumers Union;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           dot.com community sites;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           associations or other groups representing charities, including charity giving sites,
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           online directory distributors;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           internet portals;
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           accounting, law and consulting firms whose primary clients are businesses; and
         </li>
-        <li class="my-3">
+        <li class="my-3" style="max-width:54ch">
           educational institutions and trade associations.
         </li>
       </ol>
     </li>
   </ol>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We will approve link requests from these organizations if we determine that: (a) the link would not reflect unfavorably on us or our accredited businesses (for example, trade associations or other organizations representing inherently suspect types of business, such as work-at-home opportunities, shall not be allowed to link); (b)the organization does not have an unsatisfactory record with us; (c) the benefit to us from the visibility associated with the hyperlink outweighs the absence of; and (d) where the link is in the context of general resource information or is otherwise consistent with editorial content in a newsletter or similar product furthering the mission of the organization.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     These organizations may link to our home page, to publications or to other Web site information so long as the link: (a) is not in any way misleading; (b) does not falsely imply sponsorship, endorsement or approval of the linking party and it products or services; and (c) fits within the context of the linking party’s site.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     If you are among the organizations listed in paragraph 2 above and are interested in linking to our website, you must notify us by sending an e-mail to <a class="text-learnpurple hover:text-learngreen active:text-learngreen" href="mailto:hello@learnacademy.org">hello@learnacademy.org</a> Please include your name, your organization name, contact information (such as a phone number and/or e-mail address) as well as the URL of your site, a list of any URLs from which you intend to link to our Web site, and a list of the URL(s) on our site to which you would like to link. Allow 2-3 weeks for a response.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Approved organizations may hyperlink to our Web site as follows:
   </p>
   <ol>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       By use of our corporate name; or
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       By use of the uniform resource locator (Web address) being linked to; or
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       By use of any other description of our Web site or material being linked to that makes sense within the context and format of content on the linking party’s site.
     </li>
   </ol>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     No use of LEARN academy’s logo or other artwork will be allowed for linking absent a trademark license agreement.
   </p>
   <h2 class="text-learnblack text-2xl">
     Iframes
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Without prior approval and express written permission, you may not create frames around our Web pages or use other techniques that alter in any way the visual presentation or appearance of our Web site.
   </p>
   <h2 class="text-learnblack text-2xl">
     Reservation of Rights
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We reserve the right at any time and in its sole discretion to request that you remove all links or any particular link to our Web site. You agree to immediately remove all links to our Web site upon such request. We also reserve the right to amend these terms and conditions and its linking policy at any time. By continuing to link to our Web site, you agree to be bound to and abide by these linking terms and conditions.
   </p>
   <h2 class="text-learnblack text-2xl">
     Removal of links from our website
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     If you find any link on our Web site or any linked web site objectionable for any reason, you may contact us about this. We will consider requests to remove links but will have no obligation to do so or to respond directly to you.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     Whilst we endeavor to ensure that the information on this website is correct, we do not warrant its completeness or accuracy; nor do we commit to ensuring that the website remains available or that the material on the website is kept up to date.
   </p>
   <h2 class="text-learnblack text-2xl">
     Content Liability
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     We shall have no responsibility or liability for any content appearing on your Web site. You agree to indemnify and defend us against all claims arising out of or based upon your Website. No link(s) may appear on any page on your Web site or within any context containing content or materials that may be interpreted as libelous, obscene or criminal, or which infringes, otherwise violates, or advocates the infringement or other violation of, any third party rights.
   </p>
   <h2 class="text-learnblack text-2xl">
     Disclaimer
   </h2>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     To the maximum extent permitted by applicable law, we exclude all representations, warranties, and conditions relating to our website and the use of this website (including, without limitation, any warranties implied by law in respect of satisfactory quality, fitness for purpose and/or the use of reasonable care and skill). Nothing in this disclaimer will:
   </p>
   <ol>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       limit or exclude our or your liability for death or personal injury resulting from negligence;
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       limit or exclude our or your liability for fraud or fraudulent misrepresentation;
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       limit any of our or your liabilities in any way that is not permitted under applicable law; or
     </li>
-    <li class="my-3">
+    <li class="my-3" style="max-width:54ch">
       exclude any of our or your liabilities that may not be excluded under applicable law.
     </li>
   </ol>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     The limitations and exclusions of liability set out in this Section and elsewhere in this disclaimer: (a) are subject to the preceding paragraph; and (b) govern all liabilities arising under the disclaimer or in relation to the subject matter of this disclaimer, including liabilities arising in contract, in tort (including negligence) and for breach of statutory duty.
   </p>
-  <p class="my-3">
+  <p class="my-3" style="max-width:54ch">
     To the extent that the website and the information and services on the website are provided free of charge, we will not be liable for any loss or damage of any nature.
   </p>
 </div>


### PR DESCRIPTION
in about us, code of conduct, terms of use, and privacy policy to show 80 characters or less in each line. Style has 54ch since it only recognizes letters and symbols not spaces allowing for more characters to appear if 80ch inputted. Tailwind CSS options to limit lines to 80ch did not work. Each attempt stretched the lines across the whole page. The about us page had a width of 60% which exceeded the 80ch count.

# Submitting Pull Request

### Ticket

ID number: 101

Branch name: text-restraints

Description: Fixed text in about us, code of conduct, terms of use, and privacy policy to show 80 characters or less in each line. Style has 54ch since it only recognizes letters and symbols not spaces allowing for more characters to appear if 80ch inputted. Tailwind CSS options to limit lines to 80ch did not work. Each attempt stretched the lines across the whole page. The about us page had a width of 60% which exceeded the 80ch count.

Link to ticket: https://www.notion.so/2022-Golf-Internship-a4556022acd84408a34062ba09f9e6f8?p=8f9bfcc2ef104c67a97308e3e1755b1a&pm=s

### Notes

Notes for the reviewer:

Contributors: Charlie, Ramirez, Immanuel
