### PR TITLE
changed destroy to delete. moved delete button from show to edit page…

### DIFF
--- a/app/assets/stylesheets/administrate/components/_search.scss
+++ b/app/assets/stylesheets/administrate/components/_search.scss
@@ -6,6 +6,7 @@ $_search-icon-size: 1rem;
   max-width: 20rem;
   position: relative;
   width: 100%;
+  margin-top: 0.75rem;
 }
 
 .search__input {

--- a/app/views/admin/application/_form.html.erb
+++ b/app/views/admin/application/_form.html.erb
@@ -1,0 +1,45 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name, singular: true)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(controller.action_name).each do |attribute| -%>
+    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/application/edit.html.erb
+++ b/app/views/admin/application/edit.html.erb
@@ -1,0 +1,45 @@
+<%#
+# Edit
+
+This view is the template for the edit page.
+
+It displays a header, and renders the `_form` partial to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) { t("administrate.actions.edit_resource", name: page.page_title) } %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.show_resource", name: page.page_title),
+      [namespace, page.resource],
+      class: "button",
+    ) if accessible_action?(page.resource, :show) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "form", page: page %>
+  <div class="form-actions">
+    <%= link_to(
+        "Delete",
+        [namespace, page.resource],
+        class: "button button--danger delete-button",
+        method: :delete,
+        data: { confirm: "This will permanently delete the record. " + t("administrate.actions.confirm") }
+      ) if valid_action?(:destroy) && show_action?(:destroy, page.resource) %>
+    </div>
+</section>

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -1,0 +1,47 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<%=
+  render("index_header",
+    class: "index-header",
+    resources: resources,
+    search_term: search_term,
+    page: page,
+    show_search_bar: show_search_bar,
+  )
+%>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    collection_field_name: resource_name,
+    page: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= render("pagination", resources: resources) %>
+</section>

--- a/app/views/admin/application/new.html.erb
+++ b/app/views/admin/application/new.html.erb
@@ -1,0 +1,37 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) do %>
+  <%= t(
+    "administrate.actions.new_resource",
+    name: display_resource_name(page.resource_name).titleize
+  ) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to t("administrate.actions.back"), :back, class: "button" %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "form", page: page %>
+</section>

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -29,14 +29,6 @@ as well as a link to its edit page.
       [:edit, namespace, page.resource],
       class: "button",
     ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
-
-    <%= link_to(
-      t("administrate.actions.destroy"),
-      [namespace, page.resource],
-      class: "button button--danger",
-      method: :delete,
-      data: { confirm: t("administrate.actions.confirm") }
-    ) if valid_action?(:destroy) && show_action?(:destroy, page.resource) %>
   </div>
 </header>
 


### PR DESCRIPTION
…s. changed confirm message. added top margin to search bar in order to have it vertically centered

# Submitting Pull Request

### Ticket

ID number:
114
Branch name:
move-destroy-button
Description:
changed destroy to delete. moved delete button from show to edit pages. changed confirm message. added top margin to search bar in order to have it vertically centered
Link to ticket:
https://www.notion.so/2022-Hotel-Internship-870dd2f2a8c741a3a006a92f7a9598c9?p=e7e781dacd5c440da3f18df2ecb34d5c&pm=s
### Notes

Notes for the reviewer:

Contributors:
