### PR TITLE
 ✨[136] Rails: Added Alpha 2023 interns as contributors with associat…

### DIFF
--- a/app/views/static/contributors.html.erb
+++ b/app/views/static/contributors.html.erb
@@ -176,8 +176,40 @@
         linkedin: "https://www.linkedin.com/in/sarah-proctor-sd/",
         github: "https://github.com/sjproctor",
         image:"sarah.png"
-      } 
-    ] 
+      } ,
+        {
+    name: "Ronnie Maynard",
+    bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    cohort: "2023 Alpha",
+    linkedin: "https://www.linkedin.com/in/ronnie-maynard-455w/",
+    github: "https://github.com/Ronnie455",
+    image:"Ronnie.jpg"
+  } ,
+   {
+    name: "Leopoldo F Cuero",
+    bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    cohort: "2023 Alpha",
+    linkedin: "https://www.linkedin.com/in/leopoldo-cuero-0650a8202/",
+    github: "https://github.com/Melaza6",
+    image:"LeoCuero.jpg"
+  } ,
+   {
+    name: "Manny Flores",
+    bio: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+    cohort: "2023 Alpha",
+    linkedin: "https://www.linkedin.com/in/manny-flores-0816894b/",
+    github: "https://github.com/Manflo27",
+    image:"Manny.jpeg"
+  } ,
+   {
+    name: "Xavier Barker",
+    bio: "Main sheet Brethren of the Coast keelhaul lee furl booty Spanish Main spanker Yellow Jack carouser. Heave down weigh anchor piracy yawl chandler case shot trysail Davy Jones' Locker Jolly Roger quarterdeck. Bucko man-of-war lugger Sail ho Yellow Jack splice the main brace spanker heave down dead men tell no tales lass.",
+    cohort: "2023 Alpha",
+    linkedin: "https://www.linkedin.com/in/xavier-barker183/",
+    github: "https://github.com/XavierB91",
+    image:"Xavier.jpeg"
+  } 
+]
   %>
   <% contributors.map do |contributor| %>
   


### PR DESCRIPTION
…ed GitHub, Linkedin, About me, and Picture.,

# Submitting Pull Request

### Ticket

ID number: 136

Branch name: Contributors-alpha2023-Rails

Description: ✨[136] Rails: Added Alpha 2023 interns as contributors with associated GitHub, Linkedin, About me, and Picture.,

Link to ticket: https://www.notion.so/Rails-Add-yourselves-as-contributors-3b7352b3b20748b48ad51f2ae11219e7?pvs=4

### Notes

Notes for the reviewer:

Contributors:
